### PR TITLE
Fix git repository discovery in npm version

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -209,8 +209,12 @@ function dump (data, cb) {
   cb()
 }
 
-function statGitFolder (cb) {
-  fs.stat(path.join(npm.localPrefix, '.git'), cb)
+function findGitFolder(cb) {
+  git.whichAndExec(
+    [ 'rev-parse', '--git-dir' ],
+    { env: process.env }
+    cb
+  )
 }
 
 function callGitStatus (cb) {
@@ -249,11 +253,11 @@ function verifyGit (cb) {
     cb()
   }
 
-  statGitFolder(checkStatus)
+  findGitFolder(checkStatus)
 }
 
 function checkGit (localData, cb) {
-  statGitFolder(function (er) {
+  findGitFolder(function (er) {
     var doGit = !er && npm.config.get('git-tag-version')
     if (!doGit) {
       if (er) log.verbose('version', 'error checking for .git', er)


### PR DESCRIPTION
When package.json is not in the git root, then npm version bumps didn't
make a commit.

Issue was with how npm version discovered if it's in a git repository: it
assumed that it's a git repository only if .git folder is at the same
level as the package.json.

In reality you cannot make such assumptions, as the .git directory is
implementation detail.

Proper way of discovering if you're in a git directory is invoking
`git rev-parse --git-dir`.